### PR TITLE
Issue #7 event support

### DIFF
--- a/lib/aliasRestructureStack.js
+++ b/lib/aliasRestructureStack.js
@@ -11,6 +11,7 @@
 
 const BbPromise = require('bluebird');
 const _ = require('lodash');
+const utils = require('./utils');
 
 /**
  * Merge template definitions that are still in use into the new template
@@ -419,6 +420,37 @@ module.exports = {
 		return BbPromise.resolve([ currentTemplate, aliasStackTemplates ]);
 	},
 
+	aliasHandleEvents(currentTemplate, aliasStackTemplates) {
+
+		const stageStack = this._serverless.service.provider.compiledCloudFormationTemplate;
+		const aliasStack = this._serverless.service.provider.compiledCloudFormationAliasTemplate;
+
+		const subscriptions = _.assign({}, _.pickBy(_.get(stageStack, 'Resources', {}), [ 'Type', 'AWS::Lambda::EventSourceMapping' ]));
+
+		_.forOwn(subscriptions, (subscription, name) => {
+			// Reference alias as FunctionName
+			const functionNameRef = utils.findAllReferences(_.get(subscription, 'Properties.FunctionName'));
+			const functionName = _.get(functionNameRef, '[0].ref', '').replace(/LambdaFunction$/, '');
+			if (_.isEmpty(functionName)) {
+				// FIXME: Can this happen at all?
+				this._serverless.cli.log(`Strange thing: No function name defined for ${name}`);
+				return;
+			}
+
+			subscription.Properties.FunctionName = { Ref: `${functionName}Alias` };
+			subscription.DependsOn = [ `${functionName}Alias` ];
+
+			// Remove mapping from stage stack
+			delete stageStack.Resources[name];
+		});
+
+		// Move event subscriptions to alias stack
+		_.defaults(aliasStack.Resources, subscriptions);
+
+		// Forward inputs to the promise chain
+		return BbPromise.resolve([ currentTemplate, aliasStackTemplates ]);
+	},
+
 	aliasRestructureStack(currentTemplate, aliasStackTemplates) {
 
 		this._serverless.cli.log('Preparing aliase ...');
@@ -432,6 +464,7 @@ module.exports = {
 		.spread(this.aliasHandleLambdaRole)
 		.spread(this.aliasHandleFunctions)
 		.spread(this.aliasHandleApiGateway)
+		.spread(this.aliasHandleEvents)
 		.then(() => BbPromise.resolve());
 	}
 

--- a/lib/removeAlias.js
+++ b/lib/removeAlias.js
@@ -111,6 +111,7 @@ module.exports = {
 			const obsoleteRefs = _.concat(obsoleteFuncResources, obsoleteResources);
 
 			// Remove all obsolete resource references from the IAM policy statements
+			const emptyStatements = [];
 			const statementResources = utils.findReferences(currentRolePolicyStatements, obsoleteRefs);
 			_.forEach(statementResources, resourcePath => {
 				const indices = /.*?\[([0-9]+)\].*?\[([0-9]+)\]/.exec(resourcePath);
@@ -119,9 +120,12 @@ module.exports = {
 					const resourceIndex = indices[2];
 
 					_.pullAt(currentRolePolicyStatements[statementIndex].Resource, resourceIndex);
-					_.pull(currentRolePolicyStatements[statementIndex], statement => _.isEmpty(statement.Resource));
+					if (_.isEmpty(currentRolePolicyStatements[statementIndex].Resource)) {
+						emptyStatements.push(statementIndex);
+					}
 				}
 			});
+			_.pullAt(currentRolePolicyStatements, emptyStatements);
 
 			// Set references to obsoleted resources in fct env to "REMOVED" in case
 			// the alias that is removed was the last deployment of the stage.


### PR DESCRIPTION
Fixes #7 Events are subscribed to the alias they are deployed to. Same as with SLS 0.5. Fixed a small issue with alias remove in case of empty IAM refs.