### PR TITLE
Use lifecycles provided by SLS 1.12 and later.

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -4,10 +4,16 @@
  */
 
 const BbPromise = require('bluebird');
+const SemVer = require('semver');
 
 module.exports = {
 
 	validate() {
+
+		// Check required serverless version
+		if (SemVer.gt('1.12.0', this.serverless.getVersion())) {
+			return BbPromise.reject(new this.serverless.classes.Error('Serverless verion must be >= 1.12.0'));
+		}
 
 		// Parse and check plugin options
 		if (this._options['alias-resources']) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "chalk": "^1.1.3",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -71,6 +71,9 @@ describe('AwsAlias', () => {
 		let createAliasStackStub;
 		let aliasStackLoadCurrentCFStackAndDependenciesStub;
 		let aliasRestructureStackStub;
+		let setBucketNameStub;
+		let uploadAliasArtifactsStub;
+		let updateAliasStackStub;
 
 		before(() => {
 			sandbox = sinon.sandbox.create();
@@ -83,38 +86,61 @@ describe('AwsAlias', () => {
 			createAliasStackStub = sandbox.stub(awsAlias, 'createAliasStack');
 			aliasStackLoadCurrentCFStackAndDependenciesStub = sandbox.stub(awsAlias, 'aliasStackLoadCurrentCFStackAndDependencies');
 			aliasRestructureStackStub = sandbox.stub(awsAlias, 'aliasRestructureStack');
+			setBucketNameStub = sandbox.stub(awsAlias, 'setBucketName');
+			uploadAliasArtifactsStub = sandbox.stub(awsAlias, 'uploadAliasArtifacts');
+			updateAliasStackStub = sandbox.stub(awsAlias, 'updateAliasStack');
 		});
 
 		afterEach(() => {
 			sandbox.restore();
 		});
 
-		it('before:deploy:initialize should resolve', () => {
+		it('before:package:initialize should resolve', () => {
 			validateStub.returns(BbPromise.resolve());
-			return expect(awsAlias.hooks['before:deploy:initialize']()).to.eventually.be.fulfilled
+			return expect(awsAlias.hooks['before:package:initialize']()).to.eventually.be.fulfilled
 			.then(() => expect(validateStub).to.be.calledOnce);
 		});
 
-		it('after:deploy:initialize should resolve', () => {
-			configureAliasStackStub.returns(BbPromise.resolve());
-			return expect(awsAlias.hooks['after:deploy:initialize']()).to.eventually.be.fulfilled
-			.then(() => expect(configureAliasStackStub).to.be.calledOnce);
-		});
-
-		it('after:deploy:setupProviderConfiguration should resolve', () => {
-			createAliasStackStub.returns(BbPromise.resolve());
-			return expect(awsAlias.hooks['after:deploy:setupProviderConfiguration']()).to.eventually.be.fulfilled
-			.then(() => expect(createAliasStackStub).to.be.calledOnce);
-		});
-
 		it('before:deploy:deploy should resolve', () => {
+			configureAliasStackStub.returns(BbPromise.resolve());
+			return expect(awsAlias.hooks['before:deploy:deploy']()).to.eventually.be.fulfilled
+			.then(() => BbPromise.all([
+				expect(validateStub).to.be.calledOnce,
+				expect(configureAliasStackStub).to.be.calledOnce,
+			]));
+		});
+
+		it('before:aws:deploy:deploy:createStack should resolve', () => {
 			aliasStackLoadCurrentCFStackAndDependenciesStub.returns(BbPromise.resolve([]));
 			aliasRestructureStackStub.returns(BbPromise.resolve());
-			return expect(awsAlias.hooks['before:deploy:deploy']()).to.eventually.be.fulfilled
+			return expect(awsAlias.hooks['before:aws:deploy:deploy:createStack']()).to.eventually.be.fulfilled
 			.then(() => BbPromise.join(
 				expect(aliasStackLoadCurrentCFStackAndDependenciesStub).to.be.calledOnce,
 				expect(aliasRestructureStackStub).to.be.calledOnce
 			));
 		});
+
+		it('after:aws:deploy:deploy:createStack should resolve', () => {
+			createAliasStackStub.returns(BbPromise.resolve());
+			return expect(awsAlias.hooks['after:aws:deploy:deploy:createStack']()).to.eventually.be.fulfilled
+			.then(() => expect(createAliasStackStub).to.be.calledOnce);
+		});
+
+		it('after:aws:deploy:deploy:uploadArtifacts should resolve', () => {
+			setBucketNameStub.returns(BbPromise.resolve());
+			uploadAliasArtifactsStub.returns(BbPromise.resolve());
+			return expect(awsAlias.hooks['after:aws:deploy:deploy:uploadArtifacts']()).to.eventually.be.fulfilled
+			.then(() => BbPromise.join(
+				expect(setBucketNameStub).to.be.calledOnce,
+				expect(uploadAliasArtifactsStub).to.be.calledOnce
+			));
+		});
+
+		it('after:aws:deploy:deploy:updateStack should resolve', () => {
+			updateAliasStackStub.returns(BbPromise.resolve());
+			return expect(awsAlias.hooks['after:aws:deploy:deploy:updateStack']()).to.eventually.be.fulfilled
+			.then(() => expect(updateAliasStackStub).to.be.calledOnce);
+		});
+
 	});
 });

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -30,7 +30,22 @@ describe('#validate()', () => {
 		awsAlias = new AWSAlias(serverless, options);
 	});
 
-	it('should reference the deploy plugin', () => {
+	it('should fail with old Serverless version', () => {
+		serverless.version = '1.6.0';
+		return expect(awsAlias.validate()).to.be.rejectedWith('must be >= 1.12.0');
+	});
+
+	it('should succeed Serverless version 1.12.0', () => {
+		serverless.version = '1.12.0';
+		return expect(awsAlias.validate()).to.eventually.be.fulfilled;
+	});
+
+	it('should succeed Serverless version 1.13.0', () => {
+		serverless.version = '1.13.0';
+		return expect(awsAlias.validate()).to.eventually.be.fulfilled;
+	});
+
+	it('should succeed', () => {
 		return expect(awsAlias.validate()).to.eventually.be.fulfilled;
 	});
 });


### PR DESCRIPTION
Closes #20 

Hook new lifecycle events. Check serverless version.