### PR TITLE
Use separate role per alias. Fix user resource detection.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ install:
 script:
   - npm run eslint
   - npm test
-  - ls -lR test
 
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
 script:
   - npm run eslint
   - npm test
+  - ls -lR test
 
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const BbPromise = require('bluebird')
 		, stackInformation = require('./lib/stackInformation')
 		, listAliases = require('./lib/listAliases')
 		, removeAlias = require('./lib/removeAlias')
+		, collectUserResources = require('./lib/collectUserResources')
 		, uploadAliasArtifacts = require('./lib/uploadAliasArtifacts');
 
 class AwsAlias {
@@ -51,6 +52,7 @@ class AwsAlias {
 		_.assign(
 			this,
 			validate,
+			collectUserResources,
 			configureAliasStack,
 			createAliasStack,
 			updateAliasStack,
@@ -91,6 +93,9 @@ class AwsAlias {
 		this._hooks = {
 			'before:package:initialize': () => BbPromise.bind(this)
 				.then(this.validate),
+
+			'before:aws:package:finalize:mergeCustomProviderResources': () => BbPromise.bind(this)
+				.then(this.collectUserResources),
 
 			'before:deploy:deploy': () => BbPromise.bind(this)
 				.then(this.validate)

--- a/lib/aliasRestructureStack.js
+++ b/lib/aliasRestructureStack.js
@@ -22,18 +22,48 @@ const cwEvents = require('./stackops/cwEvents');
 
 module.exports = {
 
-	aliasInit: init,
-	aliasHandleFunctions: functions,
-	aliasHandleApiGateway: apiGateway,
-	aliasHandleUserResources: userResources,
-	aliasHandleLambdaRole: lambdaRole,
-	aliasHandleEvents: events,
-	aliasHandleCWEvents: cwEvents,
+	aliasInit(currentTemplate, aliasStackTemplates, currentAliasStackTemplate) {
+		return init.call(this, currentTemplate, aliasStackTemplates, currentAliasStackTemplate);
+	},
+
+	aliasHandleFunctions(currentTemplate, aliasStackTemplates, currentAliasStackTemplate) {
+		return functions.call(this, currentTemplate, aliasStackTemplates, currentAliasStackTemplate);
+	},
+
+	aliasHandleApiGateway(currentTemplate, aliasStackTemplates, currentAliasStackTemplate) {
+		return apiGateway.call(this, currentTemplate, aliasStackTemplates, currentAliasStackTemplate);
+	},
+
+	aliasHandleUserResources(currentTemplate, aliasStackTemplates, currentAliasStackTemplate) {
+		return userResources.call(this, currentTemplate, aliasStackTemplates, currentAliasStackTemplate);
+	},
+
+	aliasHandleLambdaRole(currentTemplate, aliasStackTemplates, currentAliasStackTemplate) {
+		return lambdaRole.call(this, currentTemplate, aliasStackTemplates, currentAliasStackTemplate);
+	},
+
+	aliasHandleEvents(currentTemplate, aliasStackTemplates, currentAliasStackTemplate) {
+		return events.call(this, currentTemplate, aliasStackTemplates, currentAliasStackTemplate);
+	},
+
+	aliasHandleCWEvents(currentTemplate, aliasStackTemplates, currentAliasStackTemplate) {
+		return cwEvents.call(this, currentTemplate, aliasStackTemplates, currentAliasStackTemplate);
+	},
 
 	aliasFinalize(currentTemplate, aliasStackTemplates, currentAliasStackTemplate) {
+		const stageStack = this._serverless.service.provider.compiledCloudFormationTemplate;
 		const aliasStack = this._serverless.service.provider.compiledCloudFormationAliasTemplate;
 
 		aliasStack.Outputs.AliasFlags.Value = JSON.stringify(aliasStack.Outputs.AliasFlags.Value);
+
+		// Check for missing dependencies and integrate them too
+		_.forEach(_.filter(stageStack.Resources, resource => !_.isEmpty(resource.DependsOn)), parent => {
+			_.forEach(parent.DependsOn, child => {
+				if (!_.has(stageStack.Resources, child) && _.has(currentTemplate.Resources, child)) {
+					stageStack.Resources[child] = currentTemplate.Resources[child];
+				}
+			});
+		});
 
 		return BbPromise.resolve([ currentTemplate, aliasStackTemplates, currentAliasStackTemplate ]);
 	},

--- a/lib/collectUserResources.js
+++ b/lib/collectUserResources.js
@@ -1,0 +1,18 @@
+'use strict';
+/**
+ * Persist the user resources.
+ * This is now necessary as the package command merges them already.
+ */
+
+const BbPromise = require('bluebird');
+const _ = require('lodash');
+
+module.exports = {
+	collectUserResources() {
+		this._serverless.service.provider.aliasUserResources =
+			_.cloneDeep(
+				_.get(this._serverless.service, 'resources', { Resources: {}, Outputs: {} }));
+
+		return BbPromise.resolve();
+	}
+};

--- a/lib/stackops/lambdaRole.js
+++ b/lib/stackops/lambdaRole.js
@@ -13,94 +13,51 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 
 	const stageStack = this._serverless.service.provider.compiledCloudFormationTemplate;
 	const aliasStack = this._serverless.service.provider.compiledCloudFormationAliasTemplate;
-	let stageRolePolicies = _.get(stageStack, 'Resources.IamRoleLambdaExecution.Properties.Policies', []);
-	let currentRolePolicies = _.get(currentTemplate, 'Resources.IamRoleLambdaExecution.Properties.Policies', []);
-
-	// Older serverless versions (<1.7.0) do not use a inline policy.
-	if (_.isEmpty(currentRolePolicies) && _.has(currentTemplate, 'Resources.IamPolicyLambdaExecution')) {
-		this._serverless.cli.log('WARNING: Project created with SLS < 1.7.0. Using resources from policy.');
-		currentRolePolicies = [ _.get(currentTemplate, 'Resources.IamPolicyLambdaExecution.Properties') ];
-	}
-	if (_.isEmpty(stageRolePolicies) && _.has(stageStack, 'Resources.IamPolicyLambdaExecution')) {
-		stageRolePolicies = [ _.get(stageStack, 'Resources.IamPolicyLambdaExecution.Properties') ];
-	}
 
 	// There can be a service role defined. In this case there is no embedded IAM role.
 	if (_.has(this._serverless.service.provider, 'role')) {
 		// Use the role if any of the aliases reference it
-		if (!_.isEmpty(currentRolePolicies) &&
-			_.some(aliasStackTemplates, template => !template.Outputs.AliasFlags.Value.hasRole)) {
-			stageStack.Resources.IamRoleLambdaExecution = _.cloneDeep(currentTemplate.Resources.IamRoleLambdaExecution);
-		}
-
 		aliasStack.Outputs.AliasFlags.Value.hasRole = true;
+
+		// Import all defined roles from the current template (without overwriting)
+		const currentRoles = _.assign({}, _.pickBy(currentTemplate.Resources, (resource, name) => resource.Type === 'AWS::IAM::Role' && /^IamRoleLambdaExecution/.test(name)));
+		_.defaults(stageStack.Resources, currentRoles);
+
+		// Remove old role for this alias
+		delete stageStack.Resources[`IamRoleLambdaExecution${this._alias}`];
 
 		return BbPromise.resolve([ currentTemplate, aliasStackTemplates, currentAliasStackTemplate ]);
 	}
 
-	// For now we only merge the first policy document and exit if SLS changes this behavior.
-	if (stageRolePolicies.length !== 1) {
-		return BbPromise.reject(new Error('Policy count should be 1! Please report this error to the alias plugin owner.'));
+	const roleName = `IamRoleLambdaExecution${this._alias}`;
+	const role = stageStack.Resources.IamRoleLambdaExecution;
+
+	// Set role name
+	_.last(role.Properties.RoleName['Fn::Join']).push(this._alias);
+
+	stageStack.Resources[roleName] = stageStack.Resources.IamRoleLambdaExecution;
+	delete stageStack.Resources.IamRoleLambdaExecution;
+
+	// Replace references
+	const functions = _.filter(stageStack.Resources, ['Type', 'AWS::Lambda::Function']);
+	_.forEach(functions, func => {
+		func.Properties.Role = {
+			'Fn::GetAtt': [
+				roleName,
+				'Arn'
+			]
+		};
+		const dependencyIndex = _.indexOf(func.DependsOn, 'IamRoleLambdaExecution');
+		func.DependsOn[dependencyIndex] = roleName;
+	});
+
+	if (_.isEmpty(utils.findReferences(currentTemplate.Resources, 'IamRoleLambdaExecution')) && _.has(currentTemplate, 'Resources.IamRoleLambdaExecution')) {
+		delete currentTemplate.Resources.IamRoleLambdaExecution;
 	}
 
-	const stageRolePolicyStatements = _.get(stageRolePolicies[0], 'PolicyDocument.Statement', []);
-	const currentRolePolicyStatements = _.get(currentRolePolicies[0], 'PolicyDocument.Statement', []);
-
-	_.forEach(currentRolePolicyStatements, statement => {
-		// Check if there is already a statement with the same actions and effect.
-		const sameStageStatement = _.find(stageRolePolicyStatements, value => value.Effect === statement.Effect &&
-			value.Action.length === statement.Action.length &&
-			_.every(value.Action, action => _.includes(statement.Action, action)));
-
-		if (sameStageStatement) {
-			// Merge the resources
-			sameStageStatement.Resource = _.uniqWith(_.concat(sameStageStatement.Resource, statement.Resource), (a,b) => _.isEqual(a,b));
-		} else {
-			// Add the different statement
-			stageRolePolicyStatements.push(statement);
-		}
-	});
-
-	// Remove all resource references of removed resources
-	const voidResourceRefs = utils.findReferences(stageRolePolicyStatements, this.removedResourceKeys);
-	const voidResourcePtrs = _.compact(_.map(voidResourceRefs, ref => {
-		const ptrs = /\[([0-9]+)\].Resource\[([0-9]+)\].*/.exec(ref);
-		if (ptrs && ptrs.length === 3) {
-			return { s: ptrs[1], r: ptrs[2] };
-		}
-		return null;
-	}));
-	_.forEach(voidResourcePtrs, ptr => {
-		const statement = stageRolePolicyStatements[ptr.s];
-		_.pullAt(statement.Resource, [ ptr.r ]);
-		if (_.isEmpty(statement.Resource)) {
-			_.pullAt(stageRolePolicyStatements, [ ptr.s ]);
-		}
-	});
-
-	// Insert statement dependencies
-	const dependencies = _.reject((() => {
-		const result = [];
-		const stack = [ _.first(stageRolePolicyStatements) ];
-		while (!_.isEmpty(stack)) {
-			const statement = stack.pop();
-
-			_.forOwn(statement, (value, key) => {
-				if (key === 'Ref') {
-					result.push(value);
-				} else if (key === 'Fn::GetAtt') {
-					result.push(value[0]);
-				} else if (_.isObject(value)) {
-					stack.push(value);
-				}
-			});
-		}
-		return result;
-	})(), dependency => _.has(stageStack.Resources, dependency));
-
-	_.forEach(dependencies, dependency => {
-		stageStack.Resources[dependency] = currentTemplate.Resources[dependency];
-	});
+	// Import all defined roles from the current template (without overwriting)
+	const currentRoles = _.assign({}, _.pickBy(currentTemplate.Resources, (resource, name) => resource.Type === 'AWS::IAM::Role' && /^IamRoleLambdaExecution/.test(name)));
+	_.defaults(stageStack.Resources, currentRoles);
 
 	return BbPromise.resolve([ currentTemplate, aliasStackTemplates, currentAliasStackTemplate ]);
 };

--- a/lib/stackops/userResources.js
+++ b/lib/stackops/userResources.js
@@ -13,7 +13,7 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 
 	const stageStack = this._serverless.service.provider.compiledCloudFormationTemplate;
 	const aliasStack = this._serverless.service.provider.compiledCloudFormationAliasTemplate;
-	const userResources = _.get(this._serverless.service, 'resources', { Resources: {}, Outputs: {} });
+	const userResources = _.get(this._serverless.service, 'provider.aliasUserResources', { Resources: {}, Outputs: {} });
 
 	this.options.verbose && this._serverless.cli.log('Processing custom resources');
 
@@ -24,9 +24,6 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 			const outputRefs = JSON.parse(_.get(template, 'Outputs.AliasOutputs.Value', "[]"));
 			const resources = _.assign({}, _.pick(_.get(currentTemplate, 'Resources'), resourceRefs, {}));
 			const outputs = _.assign({}, _.pick(_.get(currentTemplate, 'Outputs'), outputRefs, {}));
-
-			// Check if there are IAM policy references for the alias resources and integrate them into
-			// the lambda policy.
 
 			_.assign(result.Resources, resources);
 			_.assign(result.Outputs, outputs);
@@ -43,20 +40,26 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 	// All used resources are copied from the current template
 
 	// Extract the user resources that are not overrides of existing Serverless resources
-	const stageUserResources = _.get(userResources, 'Resources', {});
+	const currentResources = _.get(userResources, 'Resources', {});
 	const currentOutputs = _.get(userResources, 'Outputs', {});
 
-	// Store a list of all removed resources
-	const allUsedResources = _.merge({}, aliasDependencies.Resources, stageUserResources, stageStack.Resources);
-	const deployedResourceKeys = _.keys(currentTemplate.Resources);
-	const allUsedResourceKeys = _.keys(allUsedResources);
-	this.removedResourceKeys = _.filter(deployedResourceKeys, key => !_.includes(allUsedResourceKeys, key));
+	const aliasResourceRefs = _.keys(aliasDependencies.Resources);
+	//const aliasOutputRefs = _.keys(aliasDependencies.Outputs);
+	const currentResourceRefs = _.keys(currentResources);
+	//const currentOutputRefs = _.keys(currentOutputs);
+	const oldResourceRefs = JSON.parse(_.get(currentAliasStackTemplate, 'Outputs.AliasResources.Value', "[]"));
+	//const oldOutputRefs = JSON.parse(_.get(currentAliasStackTemplate, 'Outputs.AliasOutputs.Value', "[]"));
+
+	// Removed resources are resources that are no longer referenced
+
+	const removedResourceRefs = _.difference(_.difference(oldResourceRefs, currentResourceRefs), aliasResourceRefs);
+	this.removedResourceKeys = removedResourceRefs;
 	this._options.verbose && this._serverless.cli.log(`Removing resources: ${this.removedResourceKeys}`);
 
 	// Add the alias resources as output to the alias stack
 	aliasStack.Outputs.AliasResources = {
 		Description: 'Custom resource references',
-		Value: JSON.stringify(_.keys(stageUserResources))
+		Value: JSON.stringify(_.keys(currentResources))
 	};
 
 	// Add the outputs as output to the alias stack
@@ -71,7 +74,7 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 	//        immutable otherwise.
 
 	// Check if the resource is already used anywhere else with a different definition
-	_.forOwn(stageUserResources, (resource, name) => {
+	_.forOwn(currentResources, (resource, name) => {
 		if (_.has(aliasDependencies.Resources, name) && !_.isMatch(aliasDependencies.Resources[name], resource)) {
 
 			// If we deploy the master alias, allow reconfiguration of resources

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git@github.com:hyperbrain/serverless-aws-alias.git"
   },
   "scripts": {
-    "test": "istanbul cover -x test node_modules/mocha/bin/_mocha test/**/*.js -- -R spec --recursive",
+    "test": "istanbul cover -x test node_modules/mocha/bin/_mocha 'test/**/*.js' -- -R spec --recursive",
     "eslint": "node node_modules/eslint/bin/eslint.js --ext .js lib"
   },
   "author": "Frank Schmid <fschmid740@googlemail.com>",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -74,6 +74,7 @@ describe('AwsAlias', () => {
 		let setBucketNameStub;
 		let uploadAliasArtifactsStub;
 		let updateAliasStackStub;
+		let collectUserResourcesStub;
 
 		before(() => {
 			sandbox = sinon.sandbox.create();
@@ -89,6 +90,7 @@ describe('AwsAlias', () => {
 			setBucketNameStub = sandbox.stub(awsAlias, 'setBucketName');
 			uploadAliasArtifactsStub = sandbox.stub(awsAlias, 'uploadAliasArtifacts');
 			updateAliasStackStub = sandbox.stub(awsAlias, 'updateAliasStack');
+			collectUserResourcesStub = sandbox.stub(awsAlias, 'collectUserResources');
 		});
 
 		afterEach(() => {
@@ -99,6 +101,12 @@ describe('AwsAlias', () => {
 			validateStub.returns(BbPromise.resolve());
 			return expect(awsAlias.hooks['before:package:initialize']()).to.eventually.be.fulfilled
 			.then(() => expect(validateStub).to.be.calledOnce);
+		});
+
+		it('before:aws:package:finalize:mergeCustomProviderResources should resolve', () => {
+			validateStub.returns(BbPromise.resolve());
+			return expect(awsAlias.hooks['before:aws:package:finalize:mergeCustomProviderResources']()).to.eventually.be.fulfilled
+			.then(() => expect(collectUserResourcesStub).to.be.calledOnce);
 		});
 
 		it('before:deploy:deploy should resolve', () => {

--- a/test/stackops/lambdaRole.test.js
+++ b/test/stackops/lambdaRole.test.js
@@ -4,7 +4,6 @@
  */
 
 const getInstalledPath = require('get-installed-path');
-const BbPromise = require('bluebird');
 const chai = require('chai');
 const sinon = require('sinon');
 const AWSAlias = require('../../index');


### PR DESCRIPTION
Fixes #36 

Now every aliased function uses the alias role. That allows to deploy different role configurations per alias. It improves adding new resources with permissions on a separate branch.