### PR TITLE
Use stage variable to set alias in APIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,12 @@ as name.
 The created API Gateway stage has the stage variables SERVERLESS_STAGE and
 SERVERLESS_ALIAS set to the corresponding values.
 
-Upcoming: There will be a configuration possibility to configure the APIG
-stage parameters separately soon.
+If you want to test your APIG endpoints in the AWS ApiGateway console, you have
+to set the SERVERLESS_ALIAS stage variable to the alias that will be used for the
+Lambda invocation. This will call the aliased function version.
+
+Deployed stages have the alias stage variable set fixed, so a deployed alias stage is
+hard-wired to the aliased Lambda versions.
 
 ## Reference the current alias in your service
 

--- a/lib/stackops/apiGateway.js
+++ b/lib/stackops/apiGateway.js
@@ -114,7 +114,8 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 				const uriParts = method.Properties.Integration.Uri['Fn::Join'][1];
 				const funcIndex = _.findIndex(uriParts, part => _.has(part, 'Fn::GetAtt'));
 
-				uriParts.splice(funcIndex + 1, 0, `:${this._alias}`);
+				// Use the SERVERLESS_ALIAS stage variable to determine the called function alias
+				uriParts.splice(funcIndex + 1, 0, ':${stageVariables.SERVERLESS_ALIAS}');
 			}
 
 			// Check for user resource overrides


### PR DESCRIPTION
Closes #40 

The stage variable SERVERLESS_ALIAS is now used to set the alias in ApiGateway.
Now you can use the AWS console correctly to invoke a specific aliased function version.