### PR TITLE
Fix stage name retrieval

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,6 @@ class AwsAlias {
 		this._serverless = serverless;
 		this._options = options;
 		this._provider = this._serverless.getProvider('aws');
-		this._stage = this._options.stage || this._serverless.service.provider.stage;
-		this._alias = this._options.alias || this._stage;
-		this._stackName = this._provider.naming.getStackName();
-
-		// Make alias available as ${self:provider.alias}
-		this._serverless.service.provider.alias = this._alias;
 
 		/**
 		 * Load stack helpers from Serverless installation.
@@ -118,6 +112,7 @@ class AwsAlias {
 				.then(this.updateAliasStack),
 
 			'after:info:info': () => BbPromise.bind(this)
+				.then(this.validate)
 				.then(this.listAliases),
 
 			// Override the logs command - must be, because the $LATEST filter

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ class AwsAlias {
 
 	constructor(serverless, options) {
 		this._serverless = serverless;
-		this._options = options;
+		this._options = options || {};
 		this._provider = this._serverless.getProvider('aws');
 
 		/**

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -15,6 +15,14 @@ module.exports = {
 			return BbPromise.reject(new this.serverless.classes.Error('Serverless verion must be >= 1.12.0'));
 		}
 
+		// Set configuration
+		this._stage = this._provider.getStage();
+		this._alias = this._options.alias || this._stage;
+		this._stackName = this._provider.naming.getStackName();
+
+		// Make alias available as ${self:provider.alias}
+		this._serverless.service.provider.alias = this._alias;
+
 		// Parse and check plugin options
 		if (this._options['alias-resources']) {
 			this._aliasResources = true;

--- a/test/configureAliasStack.test.js
+++ b/test/configureAliasStack.test.js
@@ -63,7 +63,8 @@ describe('configureAliasStack', () => {
 			serverless.service.provider.compiledCloudFormationTemplate = require('./data/sls-stack-1.json');
 			const cfTemplate = serverless.service.provider.compiledCloudFormationTemplate;
 
-			return expect(awsAlias.configureAliasStack()).to.be.fulfilled
+			return expect(awsAlias.validate()).to.be.fulfilled
+			.then(() => expect(awsAlias.configureAliasStack()).to.be.fulfilled)
 			.then(() => BbPromise.all([
 				expect(cfTemplate).to.have.deep.property('Outputs.ServerlessAliasReference.Value', 'REFERENCE'),
 				expect(cfTemplate).to.have.deep.property('Outputs.ServerlessAliasReference.Export.Name', 'testService-myStage-ServerlessAliasReference'),

--- a/test/createAliasStack.test.js
+++ b/test/createAliasStack.test.js
@@ -39,7 +39,7 @@ describe('createAliasStack', () => {
 			stage: 'myStage',
 			region: 'us-east-1',
 		};
-		serverless.setProvider('aws', new AwsProvider(serverless));
+		serverless.setProvider('aws', new AwsProvider(serverless, options));
 		serverless.cli = new serverless.classes.CLI(serverless);
 		serverless.service.service = 'testService';
 		serverless.service.provider.compiledCloudFormationAliasTemplate = {};
@@ -58,7 +58,7 @@ describe('createAliasStack', () => {
 	describe('#createAlias()', () => {
 		it('Should call CF with correct default parameters', () => {
 			const expectedCFData = {
-				StackName: 'testService-dev-myAlias',
+				StackName: 'testService-myStage-myAlias',
 				Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
 				OnFailure: 'DELETE',
 				Parameters: [],
@@ -76,7 +76,8 @@ describe('createAliasStack', () => {
 
 			serverless.service.provider.compiledCloudFormationAliasCreateTemplate = {};
 
-			return expect(awsAlias.createAlias()).to.be.fulfilled
+			return expect(awsAlias.validate()).to.be.fulfilled
+			.then(() => expect(awsAlias.createAlias()).to.be.fulfilled)
 			.then(() => BbPromise.all([
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(monitorStackStub).to.have.been.calledOnce,
@@ -89,7 +90,7 @@ describe('createAliasStack', () => {
 
 		it('should set stack tags', () => {
 			const expectedCFData = {
-				StackName: 'testService-dev-myAlias',
+				StackName: 'testService-myStage-myAlias',
 				Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
 				OnFailure: 'DELETE',
 				Parameters: [],
@@ -111,7 +112,8 @@ describe('createAliasStack', () => {
 
 			serverless.service.provider.compiledCloudFormationAliasCreateTemplate = {};
 
-			return expect(awsAlias.createAlias()).to.be.fulfilled
+			return expect(awsAlias.validate()).to.be.fulfilled
+			.then(() => expect(awsAlias.createAlias()).to.be.fulfilled)
 			.then(() => BbPromise.all([
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,6 +33,13 @@ describe('AwsAlias', () => {
 
 	describe('constructor', () => {
 		it('should initialize the plugin without options', () => {
+			const awsAlias = new AwsAlias(serverless);
+
+			expect(awsAlias).to.have.property('_serverless', serverless);
+			expect(awsAlias).to.have.property('_options').to.deep.equal({});
+		});
+
+		it('should initialize the plugin with empty options', () => {
 			const awsAlias = new AwsAlias(serverless, {});
 
 			expect(awsAlias).to.have.property('_serverless', serverless);
@@ -50,11 +57,14 @@ describe('AwsAlias', () => {
 	it('should expose standard properties', () => {
 		const awsAlias = new AwsAlias(serverless, options);
 
+		awsAlias._stackName = 'myStack';
+
 		expect(awsAlias).to.have.property('serverless', serverless);
 		expect(awsAlias).to.have.property('options').to.deep.equal(options);
 		expect(awsAlias).to.have.property('commands', awsAlias._commands);
 		expect(awsAlias).to.have.property('hooks', awsAlias._hooks);
 		expect(awsAlias).to.have.property('provider', awsAlias._provider);
+		expect(awsAlias).to.have.property('stackName', 'myStack');
 	});
 
 	describe('hook', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -28,7 +28,7 @@ describe('AwsAlias', () => {
 			region: 'us-east-1',
 		};
 		serverless.service.service = 'myService';
-		serverless.setProvider('aws', new AwsProvider(serverless));
+		serverless.setProvider('aws', new AwsProvider(serverless, options));
 	});
 
 	describe('constructor', () => {
@@ -37,8 +37,6 @@ describe('AwsAlias', () => {
 
 			expect(awsAlias).to.have.property('_serverless', serverless);
 			expect(awsAlias).to.have.property('_options').to.deep.equal({});
-			expect(awsAlias).to.have.property('_stage', 'dev');
-			expect(awsAlias).to.have.property('_alias', 'dev');
 		});
 
 		it('should initialize the plugin with options', () => {
@@ -46,8 +44,6 @@ describe('AwsAlias', () => {
 
 			expect(awsAlias).to.have.property('_serverless', serverless);
 			expect(awsAlias).to.have.property('_options').to.deep.equal(options);
-			expect(awsAlias).to.have.property('_stage', 'myStage');
-			expect(awsAlias).to.have.property('_alias', 'myStage');
 		});
 	});
 
@@ -56,8 +52,6 @@ describe('AwsAlias', () => {
 
 		expect(awsAlias).to.have.property('serverless', serverless);
 		expect(awsAlias).to.have.property('options').to.deep.equal(options);
-		expect(awsAlias).to.have.property('stackName', 'myService-dev');
-		expect(awsAlias).to.have.deep.property('serverless.service.provider.alias', 'myStage');
 		expect(awsAlias).to.have.property('commands', awsAlias._commands);
 		expect(awsAlias).to.have.property('hooks', awsAlias._hooks);
 		expect(awsAlias).to.have.property('provider', awsAlias._provider);

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -4,6 +4,7 @@
  */
 
 const getInstalledPath = require('get-installed-path');
+const BbPromise = require('bluebird');
 const chai = require('chai');
 const AWSAlias = require('../index');
 
@@ -25,7 +26,8 @@ describe('#validate()', () => {
 			stage: 'myStage',
 			region: 'us-east-1',
 		};
-		serverless.setProvider('aws', new AwsProvider(serverless));
+		serverless.service.service = 'myService';
+		serverless.setProvider('aws', new AwsProvider(serverless, options));
 		serverless.cli = new serverless.classes.CLI(serverless);
 		awsAlias = new AWSAlias(serverless, options);
 	});
@@ -43,6 +45,15 @@ describe('#validate()', () => {
 	it('should succeed with Serverless version 1.13.0', () => {
 		serverless.version = '1.13.0';
 		return expect(awsAlias.validate()).to.eventually.be.fulfilled;
+	});
+
+	it('should initialize the plugin with options', () => {
+		return expect(awsAlias.validate()).to.eventually.be.fulfilled
+		.then(() => BbPromise.all([
+			expect(awsAlias).to.have.property('_stage', 'myStage'),
+			expect(awsAlias).to.have.property('_alias', 'myStage'),
+			expect(awsAlias).to.have.property('_stackName', 'myService-myStage'),
+		]));
 	});
 
 	it('should succeed', () => {


### PR DESCRIPTION
Fixes #45 

The initialization of `stage` and `stackName` are moved to `validate()`. This makes sure, that the service configuration has been prepared properly (variable substitution) and is ready to be used.
With the introduction of promised variable retrieval, timings have changed in SLS.