### PR TITLE
Api logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ where the inner configurations overwrite the outer ones.
 
 `HTTP Event -> FUNCTION -> SERVICE`
 
+#### API logs
+
+The generated API logs (in case you enable logging with the `loggingLevel` property)
+can be shown the same way as the function logs. The plugin adds the `serverless logs api`
+command which will show the logs for the service's API. To show logs for a specific
+deployed alias you can combine it with the `--alias` option as usual.
+
 #### The aliasStage configuration object
 
 All settings are optional, and if not specified will be set to the AWS stage defaults.
@@ -330,6 +337,11 @@ The plugin integrates with the Serverless logs command (all standard options wil
 work). Additionally, given an alias with `--alias=XXXX`, logs will show the logs
 for the selected alias. Without the alias option it will show the master alias
 (aka. stage alias).
+
+The generated API logs (in case you enable logging with the stage `loggingLevel` property)
+can be shown the same way as the function logs. The plugin adds the `serverless logs api`
+command which will show the logs for the service's API. To show logs for a specific
+deployed alias you can combine it with the `--alias` option as usual.
 
 ## The alias command
 

--- a/index.js
+++ b/index.js
@@ -141,9 +141,9 @@ class AwsAlias {
 
 			'logs:api:logs': () => BbPromise.bind(this)
 				.then(this.validate)
-				.then(this.logsValidateApi)
-				.then(this.logsGetApiLogStreams)
-				.then(this.logsShowApiLogs),
+				.then(this.apiLogsValidate)
+				.then(this.apiLogsGetLogStreams)
+				.then(this.apiLogsShowLogs),
 
 			'alias:remove:remove': () => BbPromise.bind(this)
 				.then(this.validate)

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ class AwsAlias {
 				.then(this.validate)
 				.then(this.logsValidate)
 				.then(this.logsGetLogStreams)
-				.then(this.logsShowLogs),
+				.then(this.functionLogsShowLogs),
 
 			'logs:api:logs': () => BbPromise.bind(this)
 				.then(this.validate)

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -120,19 +120,11 @@ module.exports = {
 			return `${header}${message}${os.EOL}`;
 		};
 
-		return this.logsShowLogs(logStreamNames, formatApiLogEvent);
+		return this.logsShowLogs(logStreamNames, formatApiLogEvent, this.apiLogsGetLogStreams.bind(this));
 	},
 
-	logsShowLogs(logStreamNames, formatter) {
-		if (!logStreamNames || !logStreamNames.length) {
-			if (this.options.tail) {
-				return setTimeout((() => this.logsGetLogStreams()
-					.then(nextLogStreamNames => this.logsShowLogs(nextLogStreamNames))),
-					this.options.interval);
-			}
-		}
-
-		const formatLambdaLogEvent = formatter || (event => {
+	functionLogsShowLogs(logStreamNames) {
+		const formatLambdaLogEvent = event => {
 			const msgParam = event.message;
 			let msg = msgParam;
 			const dateFormat = 'YYYY-MM-DD HH:mm:ss.SSS (Z)';
@@ -157,7 +149,19 @@ module.exports = {
 			const text = _.split(msg, `${reqId}\t`)[1];
 
 			return `${time}\t${chalk.yellow(reqId)}\t${text}`;
-		});
+		};
+
+		return this.logsShowLogs(logStreamNames, formatLambdaLogEvent, this.logsGetLogStreams.bind(this));
+	},
+
+	logsShowLogs(logStreamNames, formatter, getLogStreams) {
+		if (!logStreamNames || !logStreamNames.length) {
+			if (this.options.tail) {
+				return setTimeout((() => getLogStreams()
+					.then(nextLogStreamNames => this.logsShowLogs(nextLogStreamNames, formatter))),
+					this.options.interval);
+			}
+		}
 
 		const params = {
 			logGroupName: this.options.logGroupName || this._apiLogsLogGroup,
@@ -189,7 +193,7 @@ module.exports = {
 			.then(results => {
 				if (results.events) {
 					_.forEach(results.events, e => {
-						process.stdout.write(formatLambdaLogEvent(e));
+						process.stdout.write(formatter(e));
 					});
 				}
 
@@ -204,8 +208,8 @@ module.exports = {
 						this.options.startTime = _.last(results.events).timestamp + 1;
 					}
 
-					return setTimeout((() => this.logsGetLogStreams()
-							.then(nextLogStreamNames => this.logsShowLogs(nextLogStreamNames))),
+					return setTimeout((() => getLogStreams()
+							.then(nextLogStreamNames => this.logsShowLogs(nextLogStreamNames, formatter))),
 						this.options.interval);
 				}
 

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -38,6 +38,7 @@ module.exports = {
 			const apiResource = _.first(resources.StackResources);
 			const apiId = apiResource.PhysicalResourceId;
 			this._apiLogsLogGroup = getApiLogGroupName(apiId, this._alias);
+			this._options.interval = this._options.interval || 1000;
 
 			this.options.verbose && this.serverless.cli.log(`API id: ${apiId}`);
 			this.options.verbose && this.serverless.cli.log(`Log group: ${this._apiLogsLogGroup}`);

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -9,15 +9,41 @@ const chalk = require('chalk');
 const moment = require('moment');
 const os = require('os');
 
-module.exports = {
-	logsValidate() {
-		// validate function exists in service
-		this._lambdaName = this._serverless.service.getFunction(this.options.function).name;
+function getApiLogGroupName(apiId, alias) {
+	return `API-Gateway-Execution-Logs_${apiId}/${alias}`;
+}
 
-		this._options.interval = this._options.interval || 1000;
+module.exports = {
+
+	logsValidate() {
+		this._lambdaName = this._serverless.service.getFunction(this.options.function).name;
 		this._options.logGroupName = this._provider.naming.getLogGroupName(this._lambdaName);
+		this._options.interval = this._options.interval || 1000;
 
 		return BbPromise.resolve();
+	},
+
+	apiLogsValidate() {
+		if (this.options.function) {
+			return BbPromise.reject(new this.serverless.classes.Error('--function is not supported for API logs.'));
+		}
+
+		// Retrieve APIG id
+		return this.aliasStacksDescribeResource('ApiGatewayRestApi')
+		.then(resources => {
+			if (_.isEmpty(resources.StackResources)) {
+				return BbPromise.reject(new this.serverless.classes.Error('service does not contain any API'));
+			}
+
+			const apiResource = _.first(resources.StackResources);
+			const apiId = apiResource.PhysicalResourceId;
+			this._apiLogsLogGroup = getApiLogGroupName(apiId, this._alias);
+
+			this.options.verbose && this.serverless.cli.log(`API id: ${apiId}`);
+			this.options.verbose && this.serverless.cli.log(`Log group: ${this._apiLogsLogGroup}`);
+
+			return BbPromise.resolve();
+		});
 	},
 
 	logsGetLogStreams() {
@@ -57,7 +83,46 @@ module.exports = {
 
 	},
 
-	logsShowLogs(logStreamNames) {
+	apiLogsGetLogStreams() {
+		const params = {
+			logGroupName: this._apiLogsLogGroup,
+			descending: true,
+			limit: 50,
+			orderBy: 'LastEventTime',
+		};
+
+		return this.provider.request(
+			'CloudWatchLogs',
+			'describeLogStreams',
+			params,
+			this.options.stage,
+			this.options.region
+		)
+		.then(reply => {
+			if (!reply || _.isEmpty(reply.logStreams)) {
+				return BbPromise.reject(new this.serverless.classes.Error('No logs exist for the API'));
+			}
+
+			return _.map(reply.logStreams, stream => stream.logStreamName);
+		});
+
+	},
+
+	apiLogsShowLogs(logStreamNames) {
+		const formatApiLogEvent = event => {
+			const dateFormat = 'YYYY-MM-DD HH:mm:ss.SSS (Z)';
+			const timestamp = chalk.green(moment(event.timestamp).format(dateFormat));
+
+			const parsedMessage = /\((.*?)\) .*/.exec(event.message);
+			const header = `${timestamp} ${chalk.yellow(parsedMessage[1])}${os.EOL}`;
+			const message = chalk.gray(_.replace(event.message, /\(.*?\) /, ''));
+			return `${header}${message}${os.EOL}`;
+		};
+
+		return this.logsShowLogs(logStreamNames, formatApiLogEvent);
+	},
+
+	logsShowLogs(logStreamNames, formatter) {
 		if (!logStreamNames || !logStreamNames.length) {
 			if (this.options.tail) {
 				return setTimeout((() => this.logsGetLogStreams()
@@ -66,7 +131,8 @@ module.exports = {
 			}
 		}
 
-		const formatLambdaLogEvent = (msgParam) => {
+		const formatLambdaLogEvent = formatter || (event => {
+			const msgParam = event.message;
 			let msg = msgParam;
 			const dateFormat = 'YYYY-MM-DD HH:mm:ss.SSS (Z)';
 
@@ -90,10 +156,10 @@ module.exports = {
 			const text = _.split(msg, `${reqId}\t`)[1];
 
 			return `${time}\t${chalk.yellow(reqId)}\t${text}`;
-		};
+		});
 
 		const params = {
-			logGroupName: this.options.logGroupName,
+			logGroupName: this.options.logGroupName || this._apiLogsLogGroup,
 			interleaved: true,
 			logStreamNames,
 			startTime: this.options.startTime,
@@ -122,7 +188,7 @@ module.exports = {
 			.then(results => {
 				if (results.events) {
 					_.forEach(results.events, e => {
-						process.stdout.write(formatLambdaLogEvent(e.message));
+						process.stdout.write(formatLambdaLogEvent(e));
 					});
 				}
 

--- a/lib/stackInformation.js
+++ b/lib/stackInformation.js
@@ -103,6 +103,20 @@ module.exports = {
 			this._options.region);
 	},
 
+	aliasStacksDescribeResource(resourceId) {
+
+		const stackName = this._provider.naming.getStackName();
+
+		return this._provider.request('CloudFormation',
+			'describeStackResources',
+			{
+				StackName: stackName,
+				LogicalResourceId: resourceId
+			},
+			this._options.stage,
+			this._options.region);
+	},
+
 	aliasStacksDescribeAliases() {
 		const params = {
 			ExportName: `${this._provider.naming.getStackName()}-ServerlessAliasReference`

--- a/test/logs.test.js
+++ b/test/logs.test.js
@@ -20,28 +20,30 @@ describe('logs', () => {
 	let awsAlias;
 	// Sinon and stubs for SLS CF access
 	let sandbox;
-	//let providerRequestStub;
+	let providerRequestStub;
 	let logStub;
+	let aliasGetAliasFunctionVersionsStub;
 
 	before(() => {
 		sandbox = sinon.sandbox.create();
 	});
 
 	beforeEach(() => {
-		serverless = new Serverless();
 		options = {
 			alias: 'myAlias',
 			stage: 'dev',
 			region: 'us-east-1',
 			function: 'first'
 		};
-		serverless.setProvider('aws', new AwsProvider(serverless));
+		serverless = new Serverless(options);
+		serverless.setProvider('aws', new AwsProvider(serverless, options));
 		serverless.cli = new serverless.classes.CLI(serverless);
 		serverless.service.service = 'testService';
 		serverless.service.provider.compiledCloudFormationAliasTemplate = {};
 		awsAlias = new AWSAlias(serverless, options);
-		//providerRequestStub = sandbox.stub(awsAlias._provider, 'request');
+		providerRequestStub = sandbox.stub(awsAlias._provider, 'request');
 		logStub = sandbox.stub(serverless.cli, 'log');
+		aliasGetAliasFunctionVersionsStub = sandbox.stub(awsAlias, 'aliasGetAliasFunctionVersions');
 
 		logStub.returns();
 	});
@@ -103,25 +105,39 @@ describe('logs', () => {
 			};
 		});
 
-		/** TODO: Use fake alias log stream responses here!
-		it('should get log streams with correct params', () => {
-			const replyMock = {
+		it('should get log streams', () => {
+			const streamReply = {
 				logStreams: [
 					{
 						logStreamName: '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
 						creationTime: 1469687512311,
 					},
 					{
-						logStreamName: '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+						logStreamName: '2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E',
+						creationTime: 1469687512311,
+					},
+					{
+						logStreamName: '2016/07/28/[20]83f5206ab2a8488290349b9c1fbfe2ba',
+						creationTime: 1469687512311,
+					},
+					{
+						logStreamName: '2016/07/28/[10]83f5206ab2a8488290349b9c1fbfe2ba',
 						creationTime: 1469687512311,
 					},
 				],
 			};
-			providerRequestStub.resolves(replyMock);
+			providerRequestStub.resolves(streamReply);
+			aliasGetAliasFunctionVersionsStub.returns(BbPromise.resolve([
+				{
+					functionName: 'func1',
+					functionVersion: '20'
+				}
+			]));
+			awsAlias._lambdaName = 'func1';
 
 			return expect(awsAlias.logsGetLogStreams()).to.be.fulfilled
 			.then(logStreamNames => BbPromise.all([
-				expect(providerRequestStub).to.have.been.calledTwice,
+				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been.calledWithExactly(
 					'CloudWatchLogs',
 					'describeLogStreams',
@@ -134,15 +150,18 @@ describe('logs', () => {
 					awsAlias.options.stage,
 					awsAlias.options.region
 				),
+				expect(logStreamNames).to.have.lengthOf(2),
 				expect(logStreamNames[0])
-					.to.be.equal('2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba'),
+					.to.be.equal('2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E'),
 				expect(logStreamNames[1])
-					.to.be.equal('2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba'),
+					.to.be.equal('2016/07/28/[20]83f5206ab2a8488290349b9c1fbfe2ba'),
 			]));
 		});
 
 		it('should throw error if no log streams found', () => {
 			providerRequestStub.resolves();
+			aliasGetAliasFunctionVersionsStub.returns(BbPromise.resolve([]));
+
 			return expect(awsAlias.logsGetLogStreams()).to.be.rejectedWith("");
 		});
 	});
@@ -164,20 +183,20 @@ describe('logs', () => {
 			const replyMock = {
 				events: [
 					{
-						logStreamName: '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+						logStreamName: '2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E',
 						timestamp: 1469687512311,
 						message: 'test',
 					},
 					{
-						logStreamName: '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+						logStreamName: '2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E',
 						timestamp: 1469687512311,
 						message: 'test',
 					},
 				],
 			};
 			const logStreamNamesMock = [
-				'2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
-				'2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+				'2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E',
+				'2016/07/28/[20]83f5206ab2a8488290349b9c1fbfe2ba',
 			];
 			providerRequestStub.resolves(replyMock);
 			awsAlias.serverless.service.service = 'new-service';
@@ -188,6 +207,7 @@ describe('logs', () => {
 				logGroupName: awsAlias.provider.naming.getLogGroupName('new-service-dev-first'),
 				startTime: '3h',
 				filter: 'error',
+				alias: 'myAlias',
 			};
 
 			return expect(awsAlias.logsShowLogs(logStreamNamesMock)).to.be.fulfilled
@@ -213,52 +233,50 @@ describe('logs', () => {
 			const replyMock = {
 				events: [
 					{
-						logStreamName: '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+						logStreamName: '2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E',
 						timestamp: 1469687512311,
 						message: 'test',
 					},
 					{
-						logStreamName: '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+						logStreamName: '2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E',
 						timestamp: 1469687512311,
 						message: 'test',
 					},
 				],
 			};
 			const logStreamNamesMock = [
-				'2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
-				'2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+				'2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E',
+				'2016/07/28/[20]83f5206ab2a8488290349b9c1fbfe2ba',
 			];
-			const filterLogEventsStub = sinon.stub(awsLogs.provider, 'request').resolves(replyMock);
-			awsLogs.serverless.service.service = 'new-service';
-			awsLogs.options = {
+			providerRequestStub.resolves(replyMock);
+			awsAlias.serverless.service.service = 'new-service';
+			awsAlias._options = {
 				stage: 'dev',
 				region: 'us-east-1',
-				function: 'first',
-				logGroupName: awsLogs.provider.naming.getLogGroupName('new-service-dev-first'),
+				function: 'func1',
+				logGroupName: awsAlias.provider.naming.getLogGroupName('new-service-dev-func1'),
 				startTime: '2010-10-20',
 				filter: 'error',
+				alias: 'myAlias',
 			};
 
-			return awsLogs.showLogs(logStreamNamesMock)
-				.then(() => {
-					expect(filterLogEventsStub.calledOnce).to.be.equal(true);
-					expect(filterLogEventsStub.calledWithExactly(
+			return expect(awsAlias.logsShowLogs(logStreamNamesMock)).to.be.fulfilled
+				.then(() => BbPromise.all([
+					expect(providerRequestStub).to.have.been.calledOnce,
+					expect(providerRequestStub).to.have.been.calledWithExactly(
 						'CloudWatchLogs',
 						'filterLogEvents',
 						{
-							logGroupName: awsLogs.provider.naming.getLogGroupName('new-service-dev-first'),
+							logGroupName: awsAlias.provider.naming.getLogGroupName('new-service-dev-func1'),
 							interleaved: true,
 							logStreamNames: logStreamNamesMock,
-							startTime: 1287532800000, // '2010-10-20'
+							startTime: 1287532800000,
 							filterPattern: 'error',
 						},
-						awsLogs.options.stage,
-						awsLogs.options.region
-					)).to.be.equal(true);
-
-					awsLogs.provider.request.restore();
-				});
+						awsAlias.options.stage,
+						awsAlias.options.region
+					),
+				]));
 		});
-		*/
 	});
 });

--- a/test/logs.test.js
+++ b/test/logs.test.js
@@ -323,12 +323,12 @@ describe('logs', () => {
 					{
 						logStreamName: '2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E',
 						timestamp: 1469687512311,
-						message: 'test',
+						message: '',
 					},
 					{
 						logStreamName: '2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E',
 						timestamp: 1469687512311,
-						message: 'test',
+						message: '',
 					},
 				],
 			};
@@ -373,12 +373,12 @@ describe('logs', () => {
 					{
 						logStreamName: '2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E',
 						timestamp: 1469687512311,
-						message: 'test',
+						message: '',
 					},
 					{
 						logStreamName: '2016/07/28/[20]BE6A2C395AA244C8B7069D8C48B03B9E',
 						timestamp: 1469687512311,
-						message: 'test',
+						message: '',
 					},
 				],
 			};

--- a/test/logs.test.js
+++ b/test/logs.test.js
@@ -304,7 +304,7 @@ describe('logs', () => {
 		});
 	});
 
-	describe('#logsShowLogs()', () => {
+	describe('#functionLogsShowLogs()', () => {
 		let clock;
 
 		beforeEach(() => {
@@ -348,7 +348,7 @@ describe('logs', () => {
 				alias: 'myAlias',
 			};
 
-			return expect(awsAlias.logsShowLogs(logStreamNamesMock)).to.be.fulfilled
+			return expect(awsAlias.functionLogsShowLogs(logStreamNamesMock)).to.be.fulfilled
 			.then(() => BbPromise.all([
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been.calledWithExactly(
@@ -398,7 +398,7 @@ describe('logs', () => {
 				alias: 'myAlias',
 			};
 
-			return expect(awsAlias.logsShowLogs(logStreamNamesMock)).to.be.fulfilled
+			return expect(awsAlias.functionLogsShowLogs(logStreamNamesMock)).to.be.fulfilled
 				.then(() => BbPromise.all([
 					expect(providerRequestStub).to.have.been.calledOnce,
 					expect(providerRequestStub).to.have.been.calledWithExactly(


### PR DESCRIPTION
When the plugin is enabled, `serverless logs api` is available, which will provide the same functionality as `serverless logs`, just for the API logs.

The API logging has to be configured first, using the `aliasStage` configuration.