### PR TITLE
Support Lambda@Edge functions

### DIFF
--- a/lib/stackops/functions.js
+++ b/lib/stackops/functions.js
@@ -83,7 +83,8 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 
 	// Set SERVERLESS_ALIAS environment variable
 	_.forOwn(stageStack.Resources, resource => {
-		if (resource.Type === 'AWS::Lambda::Function') {
+		const lambdaEdgeFunctions = this._serverless.service.custom.lambdaEdgeFunctions || [];
+		if (resource.Type === 'AWS::Lambda::Function' && !_.includes(lambdaEdgeFunctions, resource.Properties.FunctionName)) {
 			_.set(resource, 'Properties.Environment.Variables.SERVERLESS_ALIAS', this._alias);
 		}
 	});


### PR DESCRIPTION
Lambda@Edge functions do not allow Environment Variables. This change
skips creation of the SERVERLESS_ALIAS env var for any functions listed
as Lambda@Edge functions in cfg below.

I'm certainly open to other implementation approaches, but it'd be great
to be able to use this plugin in combination with Lambda@Edge. If you agree to the PR, I'll add README updates as well.

```
custom:
  lambdaEdgeFunctions:
    - platform-spa-origin-request-lambda-edge
```