### PR TITLE
Support ANY type endpoints with stage configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /coverage
+/.nyc_output

--- a/lib/stackops/apiGateway.js
+++ b/lib/stackops/apiGateway.js
@@ -80,6 +80,16 @@ const internal = {
 				if (!_.isEmpty(eventStageConfig)) {
 					const methodType = _.toUpper(httpEvent.method);
 					const methodSetting = {};
+					const methods = methodType === 'ANY' ? [
+						'DELETE',
+						'GET',
+						'HEAD',
+						'OPTIONS',
+						'PATCH',
+						'POST',
+						'PUT'
+					]: [ methodType ];
+
 					_.forOwn(eventStageConfig, (value, key) => {
 						if (!_.has(stageMethodConfigMappings, key)) {
 							throw new this.serverless.classes.Error(`Invalid stage config '${key}' at method '${methodType} /${httpEvent.path}'`);
@@ -91,9 +101,11 @@ const internal = {
 						}
 					});
 					if (!_.isEmpty(methodSetting)) {
-						methodSetting.HttpMethod = methodType;
 						methodSetting.ResourcePath = '/' + _.replace('/' + _.trimStart(httpEvent.path, '/'), /\//g, '~1');
-						methodSettings.push(methodSetting);
+						_.forEach(methods, method => {
+							methodSetting.HttpMethod = method;
+							methodSettings.push(_.clone(methodSetting));
+						});
 					}
 				}
 			});

--- a/test/stackops/apiGateway.test.js
+++ b/test/stackops/apiGateway.test.js
@@ -223,6 +223,17 @@ describe('API Gateway', () => {
 							}
 						]
 					},
+					functionC: {
+						handler: 'functionB.handler',
+						events: [
+							{
+								http: {
+									method: 'ANY',
+									path: '/funcC'
+								}
+							},
+						]
+					},
 				}
 			};
 			const expectedMethodSettings = [
@@ -245,6 +256,41 @@ describe('API Gateway', () => {
 					LoggingLevel: 'INFO',
 					HttpMethod: 'UPDATE',
 					ResourcePath: '/~1funcB~1update'
+				},
+				{
+					LoggingLevel: 'INFO',
+					HttpMethod: 'DELETE',
+					ResourcePath: '/~1funcC'
+				},
+				{
+					LoggingLevel: 'INFO',
+					HttpMethod: 'GET',
+					ResourcePath: '/~1funcC'
+				},
+				{
+					LoggingLevel: 'INFO',
+					HttpMethod: 'HEAD',
+					ResourcePath: '/~1funcC'
+				},
+				{
+					LoggingLevel: 'INFO',
+					HttpMethod: 'OPTIONS',
+					ResourcePath: '/~1funcC'
+				},
+				{
+					LoggingLevel: 'INFO',
+					HttpMethod: 'PATCH',
+					ResourcePath: '/~1funcC'
+				},
+				{
+					LoggingLevel: 'INFO',
+					HttpMethod: 'POST',
+					ResourcePath: '/~1funcC'
+				},
+				{
+					LoggingLevel: 'INFO',
+					HttpMethod: 'PUT',
+					ResourcePath: '/~1funcC'
 				},
 			];
 


### PR DESCRIPTION
Fixes: #80

According to AWS, stage configurations have to refer to '*' to catch all methods or paths.

In case of endpoints defined with `ANY` as method, we have to use `*` as method.