### PR TITLE
Set SERVERLESS_ALIAS during build

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -23,6 +23,9 @@ module.exports = {
 		// Make alias available as ${self:provider.alias}
 		this._serverless.service.provider.alias = this._alias;
 
+		// Set SERVERLESS_ALIAS environment variable to let other plugins access it during the build
+		process.env.SERVERLESS_ALIAS = this._alias;
+
 		// Parse and check plugin options
 		if (this._options['alias-resources']) {
 			this._aliasResources = true;

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -56,6 +56,11 @@ describe('#validate()', () => {
 		]));
 	});
 
+	it('should set SERVERLESS_ALIAS', () => {
+		return expect(awsAlias.validate()).to.eventually.be.fulfilled
+		.then(() => expect(process.env.SERVERLESS_ALIAS).to.equal('myStage'));
+	});
+
 	it('should succeed', () => {
 		return expect(awsAlias.validate()).to.eventually.be.fulfilled;
 	});


### PR DESCRIPTION
Fixes #72 

The warmup plugin (and maybe others as well) uses the SERVERLESS_ALIAS environment variable to determine if the functions are deployed to a specific alias.

Until now the variable was only available at runtime, so the evaluation failed.

It is now set in the validate() function, so that the plugins can easily grab it.