### PR TITLE
Enhance alias logs function #89 #62

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,9 @@ class AwsAlias {
 			logCommand.options.alias = {
 				usage: 'Alias'
 			};
+			logCommand.options.version = {
+				usage: 'Logs a specific version of the function'
+			};
 			logCommand.commands = _.assign({}, logCommand.commands, {
 				api: {
 					usage: 'Output the logs of a deployed APIG stage (alias)',

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -66,27 +66,29 @@ module.exports = {
 		// setup the stream filter correctly
 		return aliasGetAliasFunctionVersion
 		.then(version => {
-			return this.provider
-				.request('CloudWatchLogs',
-					'describeLogStreams',
-					params,
-					this.options.stage,
-					this.options.region)
-				.then(reply => {
-					if (!reply || _.isEmpty(reply.logStreams)) {
-						throw new this.serverless.classes
-							.Error('No existing streams for the function alias');
-					}
-					const logStreamNames = _.map(
-						_.filter(reply.logStreams, stream => _.includes(stream.logStreamName, `[${version}]`)),
-						stream => stream.logStreamName);
+			if (version) {
+				return this.provider
+					.request('CloudWatchLogs',
+						'describeLogStreams',
+						params,
+						this.options.stage,
+						this.options.region)
+					.then(reply => {
+						if (!reply || _.isEmpty(reply.logStreams)) {
+							throw new this.serverless.classes
+								.Error('No existing streams for the function alias');
+						}
+						const logStreamNames = _.map(
+							_.filter(reply.logStreams, stream => _.includes(stream.logStreamName, `[${version}]`)),
+							stream => stream.logStreamName);
 
-					if (_.isEmpty(logStreamNames)) {
-						return BbPromise.reject(new this.serverless.classes
-							.Error('No existing streams for the latest version of function alias. If you want to view logs of a specific function version, please use --version to specify'));
-					}
-					return logStreamNames
-				});
+						if (_.isEmpty(logStreamNames)) {
+							return BbPromise.reject(new this.serverless.classes.Error('No existing streams for the latest version of function alias. If you want to view logs of a specific function version, please use --version to specify'));
+						}
+						return logStreamNames;
+					});
+			}
+			return BbPromise.reject(new this.serverless.classes.Error('Function alias not found.'));
 		});
 
 	},

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -77,9 +77,15 @@ module.exports = {
 						throw new this.serverless.classes
 							.Error('No existing streams for the function alias');
 					}
-					return _.map(
+					const logStreamNames = _.map(
 						_.filter(reply.logStreams, stream => _.includes(stream.logStreamName, `[${version}]`)),
 						stream => stream.logStreamName);
+
+					if (_.isEmpty(logStreamNames)) {
+						return BbPromise.reject(new this.serverless.classes
+							.Error('No existing streams for the latest version of function alias. If you want to view logs of a specific function version, please use --version to specify'));
+					}
+					return logStreamNames
 				});
 		});
 
@@ -125,10 +131,6 @@ module.exports = {
 	},
 
 	functionLogsShowLogs(logStreamNames) {
-		if (_.isEmpty(logStreamNames)) {
-			return BbPromise.reject(new this.serverless.classes
-				.Error('No existing streams for the latest version of function alias. If you want to view logs of a specific function version, please use --version to specify'));
-		}
 		const formatLambdaLogEvent = event => {
 			const msgParam = event.message;
 			let msg = msgParam;

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -55,12 +55,12 @@ module.exports = {
 			orderBy: 'LastEventTime',
 		};
 
-		let aliasGetAliasFunctionVersion
+		let aliasGetAliasFunctionVersion;
 		// Check if --version is specified
 		if (this._options.version) {
-			aliasGetAliasFunctionVersion = BbPromise.resolve(this._options.version)
+			aliasGetAliasFunctionVersion = BbPromise.resolve(this._options.version);
 		} else {
-			aliasGetAliasFunctionVersion = this.aliasGetAliasLatestFunctionVersionByFunctionName(this._alias, this._lambdaName)
+			aliasGetAliasFunctionVersion = this.aliasGetAliasLatestFunctionVersionByFunctionName(this._alias, this._lambdaName);
 		}
 		// Get currently deployed function version for the alias to
 		// setup the stream filter correctly
@@ -125,7 +125,7 @@ module.exports = {
 	},
 
 	functionLogsShowLogs(logStreamNames) {
-		if (logStreamNames.length === 0) {
+		if (_.isEmpty(logStreamNames)) {
 			return BbPromise.reject(new this.serverless.classes
 				.Error('No existing streams for the latest version of function alias. If you want to view logs of a specific function version, please use --version to specify'));
 		}

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -126,7 +126,7 @@ module.exports = {
 
 	functionLogsShowLogs(logStreamNames) {
 		if (logStreamNames.length === 0) {
-			return BbPromise.reject(throw new this.serverless.classes
+			return BbPromise.reject(new this.serverless.classes
 				.Error('No existing streams for the latest version of function alias. If you want to view logs of a specific function version, please use --version to specify'));
 		}
 		const formatLambdaLogEvent = event => {

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -66,31 +66,31 @@ module.exports = {
 		// setup the stream filter correctly
 		return aliasGetAliasFunctionVersion
 		.then(version => {
-			if (version) {
-				return this.provider
-					.request('CloudWatchLogs',
-						'describeLogStreams',
-						params,
-						this.options.stage,
-						this.options.region)
-					.then(reply => {
-						if (!reply || _.isEmpty(reply.logStreams)) {
-							throw new this.serverless.classes
-								.Error('No existing streams for the function alias');
-						}
-						const logStreamNames = _.map(
-							_.filter(reply.logStreams, stream => _.includes(stream.logStreamName, `[${version}]`)),
-							stream => stream.logStreamName);
-
-						if (_.isEmpty(logStreamNames)) {
-							return BbPromise.reject(new this.serverless.classes.Error('No existing streams for the latest version of function alias. If you want to view logs of a specific function version, please use --version to specify'));
-						}
-						return logStreamNames;
-					});
+			if (!version) {
+				return BbPromise.reject(new this.serverless.classes.Error('Function alias not found.'));
 			}
-			return BbPromise.reject(new this.serverless.classes.Error('Function alias not found.'));
-		});
 
+			return this.provider
+				.request('CloudWatchLogs',
+					'describeLogStreams',
+					params,
+					this.options.stage,
+					this.options.region)
+				.then(reply => {
+					if (!reply || _.isEmpty(reply.logStreams)) {
+						throw new this.serverless.classes
+							.Error('No existing streams for the function alias');
+					}
+					const logStreamNames = _.map(
+						_.filter(reply.logStreams, stream => _.includes(stream.logStreamName, `[${version}]`)),
+						stream => stream.logStreamName);
+
+					if (_.isEmpty(logStreamNames)) {
+						return BbPromise.reject(new this.serverless.classes.Error('No existing streams for this function version. If you want to view logs of a specific function version, please use --version'));
+					}
+					return logStreamNames;
+				});
+		});
 	},
 
 	apiLogsGetLogStreams() {

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -55,14 +55,16 @@ module.exports = {
 			orderBy: 'LastEventTime',
 		};
 
+		let aliasGetAliasFunctionVersion
+		// Check if --version is specified
+		if (this._options.version) {
+			aliasGetAliasFunctionVersion = Promise.resolve(this._options.version)
+		} else {
+			aliasGetAliasFunctionVersion = this.aliasGetAliasLatestFunctionVersionByFunctionName(this._alias, this._lambdaName)
+		}
 		// Get currently deployed function version for the alias to
 		// setup the stream filter correctly
-		return this.aliasGetAliasFunctionVersions(this._alias)
-		.then(versions => {
-			return _.map(
-				_.filter(versions, [ 'functionName', this._lambdaName ]),
-				version => version.functionVersion);
-		})
+		return aliasGetAliasFunctionVersion
 		.then(version => {
 			return this.provider
 				.request('CloudWatchLogs',
@@ -75,7 +77,6 @@ module.exports = {
 						throw new this.serverless.classes
 							.Error('No existing streams for the function alias');
 					}
-
 					return _.map(
 						_.filter(reply.logStreams, stream => _.includes(stream.logStreamName, `[${version}]`)),
 						stream => stream.logStreamName);
@@ -124,6 +125,10 @@ module.exports = {
 	},
 
 	functionLogsShowLogs(logStreamNames) {
+		if (logStreamNames.length === 0) {
+			throw new this.serverless.classes
+				.Error('No existing streams for the latest version of function alias. If you want to view logs of a specific function version, please use --version to specify');
+		}
 		const formatLambdaLogEvent = event => {
 			const msgParam = event.message;
 			let msg = msgParam;

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -58,7 +58,7 @@ module.exports = {
 		let aliasGetAliasFunctionVersion
 		// Check if --version is specified
 		if (this._options.version) {
-			aliasGetAliasFunctionVersion = Promise.resolve(this._options.version)
+			aliasGetAliasFunctionVersion = BbPromise.resolve(this._options.version)
 		} else {
 			aliasGetAliasFunctionVersion = this.aliasGetAliasLatestFunctionVersionByFunctionName(this._alias, this._lambdaName)
 		}
@@ -126,8 +126,8 @@ module.exports = {
 
 	functionLogsShowLogs(logStreamNames) {
 		if (logStreamNames.length === 0) {
-			throw new this.serverless.classes
-				.Error('No existing streams for the latest version of function alias. If you want to view logs of a specific function version, please use --version to specify');
+			return BbPromise.reject(throw new this.serverless.classes
+				.Error('No existing streams for the latest version of function alias. If you want to view logs of a specific function version, please use --version to specify'));
 		}
 		const formatLambdaLogEvent = event => {
 			const msgParam = event.message;

--- a/lib/stackInformation.js
+++ b/lib/stackInformation.js
@@ -187,9 +187,7 @@ module.exports = {
 			{ FunctionName: functionName, Name: aliasName },
 			this._options.stage,
 			this._options.region)
-			.then(result => {
-				return result.FunctionVersion
-			})
+			.then(result => _.get(result, 'FunctionVersion', null));
 	},
 
 };

--- a/lib/stackInformation.js
+++ b/lib/stackInformation.js
@@ -181,4 +181,15 @@ module.exports = {
 		});
 	},
 
+	aliasGetAliasLatestFunctionVersionByFunctionName(aliasName, functionName) {
+		return this._provider.request('Lambda',
+			'getAlias',
+			{ FunctionName: functionName, Name: aliasName },
+			this._options.stage,
+			this._options.region)
+			.then(result => {
+				return result.FunctionVersion
+			})
+	},
+
 };

--- a/test/logs.test.js
+++ b/test/logs.test.js
@@ -23,7 +23,7 @@ describe('logs', () => {
 	let sandbox;
 	let providerRequestStub;
 	let logStub;
-	let aliasGetAliasFunctionVersionsStub;
+	let aliasGetAliasLatestFunctionVersionByFunctionNameStub;
 	let aliasStacksDescribeResourceStub;
 
 	before(() => {
@@ -45,7 +45,7 @@ describe('logs', () => {
 		awsAlias = new AWSAlias(serverless, options);
 		providerRequestStub = sandbox.stub(awsAlias._provider, 'request');
 		logStub = sandbox.stub(serverless.cli, 'log');
-		aliasGetAliasFunctionVersionsStub = sandbox.stub(awsAlias, 'aliasGetAliasFunctionVersions');
+		aliasGetAliasLatestFunctionVersionByFunctionNameStub = sandbox.stub(awsAlias, 'aliasGetAliasLatestFunctionVersionByFunctionName');
 		aliasStacksDescribeResourceStub = sandbox.stub(awsAlias, 'aliasStacksDescribeResource');
 
 		logStub.returns();
@@ -206,12 +206,7 @@ describe('logs', () => {
 				],
 			};
 			providerRequestStub.resolves(streamReply);
-			aliasGetAliasFunctionVersionsStub.returns(BbPromise.resolve([
-				{
-					functionName: 'func1',
-					functionVersion: '20'
-				}
-			]));
+			aliasGetAliasLatestFunctionVersionByFunctionNameStub.returns(BbPromise.resolve('20'));
 			awsAlias._lambdaName = 'func1';
 
 			return expect(awsAlias.logsGetLogStreams()).to.be.fulfilled
@@ -239,7 +234,7 @@ describe('logs', () => {
 
 		it('should throw error if no log streams found', () => {
 			providerRequestStub.resolves();
-			aliasGetAliasFunctionVersionsStub.returns(BbPromise.resolve([]));
+			aliasGetAliasLatestFunctionVersionByFunctionNameStub.returns(BbPromise.resolve(null));
 
 			return expect(awsAlias.logsGetLogStreams()).to.be.rejectedWith("");
 		});


### PR DESCRIPTION
* alias logs will now pull the latest version logs from “Lambda”
service directly if --version flag is not specificed.
* Added --version flag to alias logs, so that user can view logs of a
specific version of function.

Closes #89 
Closes #62 