### PR TITLE
Added support to have an alias subscribe to an existing SNS topic #94

### DIFF
--- a/lib/stackops/snsEvents.js
+++ b/lib/stackops/snsEvents.js
@@ -47,20 +47,20 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 	});
 
     const snsSubscriptions =
-        _.assign({},
-        _.pickBy(stageStack.Resources, [ 'Type', 'AWS::SNS::Subscription' ]));
+			_.assign({},
+			_.pickBy(stageStack.Resources, [ 'Type', 'AWS::SNS::Subscription' ]));
 
-        _.forOwn(snsSubscriptions, (subscription, name) => {
+			_.forOwn(snsSubscriptions, (subscription, name) => {
 
-        const functionNameRef = utils.findAllReferences(_.get(subscription.Properties, 'Endpoint'));
-        const functionName = _.replace(_.get(functionNameRef, '[0].ref', ''), /LambdaFunction$/, '');
-        const versionName = _.find(_.keys(versions), version => _.startsWith(version, functionName));
-        const aliasName = _.find(_.keys(aliases), alias => _.startsWith(alias, functionName));
+			const functionNameRef = utils.findAllReferences(_.get(subscription.Properties, 'Endpoint'));
+			const functionName = _.replace(_.get(functionNameRef, '[0].ref', ''), /LambdaFunction$/, '');
+			const versionName = _.find(_.keys(versions), version => _.startsWith(version, functionName));
+			const aliasName = _.find(_.keys(aliases), alias => _.startsWith(alias, functionName));
 
-        subscription.Properties.Endpoint = { Ref: aliasName };
-        subscription.DependsOn = [ versionName, aliasName ];
+			subscription.Properties.Endpoint = { Ref: aliasName };
+			subscription.DependsOn = [ versionName, aliasName ];
 
-        delete stageStack.Resources[name];
+			delete stageStack.Resources[name];
     });
 
 	// Fetch lambda permissions. These have to be updated later to allow the aliased functions.
@@ -87,9 +87,9 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 	});
 
 	// Add all alias stack owned resources
-    aliasResources.push(snsTopics);
-    aliasResources.push(snsSubscriptions);
-    aliasResources.push(snsLambdaPermissions);
+	aliasResources.push(snsTopics);
+	aliasResources.push(snsSubscriptions);
+	aliasResources.push(snsLambdaPermissions);
 
 	_.forEach(aliasResources, resource => _.assign(aliasStack.Resources, resource));
 

--- a/lib/stackops/snsEvents.js
+++ b/lib/stackops/snsEvents.js
@@ -46,6 +46,23 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 		delete stageStack.Resources[name];
 	});
 
+    const snsSubscriptions =
+        _.assign({},
+        _.pickBy(stageStack.Resources, [ 'Type', 'AWS::SNS::Subscription' ]));
+
+        _.forOwn(snsSubscriptions, (subscription, name) => {
+
+        const functionNameRef = utils.findAllReferences(_.get(subscription.Properties, 'Endpoint'));
+        const functionName = _.replace(_.get(functionNameRef, '[0].ref', ''), /LambdaFunction$/, '');
+        const versionName = _.find(_.keys(versions), version => _.startsWith(version, functionName));
+        const aliasName = _.find(_.keys(aliases), alias => _.startsWith(alias, functionName));
+
+        subscription.Properties.Endpoint = { Ref: aliasName };
+        subscription.DependsOn = [ versionName, aliasName ];
+
+        delete stageStack.Resources[name];
+    });
+
 	// Fetch lambda permissions. These have to be updated later to allow the aliased functions.
 	const snsLambdaPermissions =
 			_.assign({},
@@ -71,6 +88,7 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 
 	// Add all alias stack owned resources
 	aliasResources.push(snsTopics);
+    aliasResources.push(snsSubscriptions);
 	aliasResources.push(snsLambdaPermissions);
 
 	_.forEach(aliasResources, resource => _.assign(aliasStack.Resources, resource));

--- a/lib/stackops/snsEvents.js
+++ b/lib/stackops/snsEvents.js
@@ -46,22 +46,22 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 		delete stageStack.Resources[name];
 	});
 
-    const snsSubscriptions =
-			_.assign({},
+	const snsSubscriptions =
+		_.assign({},
 			_.pickBy(stageStack.Resources, [ 'Type', 'AWS::SNS::Subscription' ]));
 
-			_.forOwn(snsSubscriptions, (subscription, name) => {
+	_.forOwn(snsSubscriptions, (subscription, name) => {
 
-			const functionNameRef = utils.findAllReferences(_.get(subscription.Properties, 'Endpoint'));
-			const functionName = _.replace(_.get(functionNameRef, '[0].ref', ''), /LambdaFunction$/, '');
-			const versionName = _.find(_.keys(versions), version => _.startsWith(version, functionName));
-			const aliasName = _.find(_.keys(aliases), alias => _.startsWith(alias, functionName));
+		const functionNameRef = utils.findAllReferences(_.get(subscription.Properties, 'Endpoint'));
+		const functionName = _.replace(_.get(functionNameRef, '[0].ref', ''), /LambdaFunction$/, '');
+		const versionName = _.find(_.keys(versions), version => _.startsWith(version, functionName));
+		const aliasName = _.find(_.keys(aliases), alias => _.startsWith(alias, functionName));
 
-			subscription.Properties.Endpoint = { Ref: aliasName };
-			subscription.DependsOn = [ versionName, aliasName ];
+		subscription.Properties.Endpoint = { Ref: aliasName };
+		subscription.DependsOn = [ versionName, aliasName ];
 
-			delete stageStack.Resources[name];
-    });
+		delete stageStack.Resources[name];
+	});
 
 	// Fetch lambda permissions. These have to be updated later to allow the aliased functions.
 	const snsLambdaPermissions =

--- a/lib/stackops/snsEvents.js
+++ b/lib/stackops/snsEvents.js
@@ -87,9 +87,9 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 	});
 
 	// Add all alias stack owned resources
-	aliasResources.push(snsTopics);
+    aliasResources.push(snsTopics);
     aliasResources.push(snsSubscriptions);
-	aliasResources.push(snsLambdaPermissions);
+    aliasResources.push(snsLambdaPermissions);
 
 	_.forEach(aliasResources, resource => _.assign(aliasStack.Resources, resource));
 

--- a/test/data/sns-stack.json
+++ b/test/data/sns-stack.json
@@ -250,6 +250,24 @@
         ]
       }
     },
+    "SNSTopicSubscriptionSlstestprojecttopic": {
+      "Type" : "AWS::SNS::Subscription",
+      "Properties": {
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "Testfct1LambdaFunction",
+            "Arn"
+          ]
+        },
+        "Protocol": "lambda",
+        "TopicArn": {
+          "Fn::GetAtt": [
+            "SNSTopicSlstestprojecttopic",
+            "Arn"
+          ]
+        }
+      }
+    },
     "Testfct1LambdaPermissionSlstestprojecttopicSNS": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {

--- a/test/stackops/snsEvents.test.js
+++ b/test/stackops/snsEvents.test.js
@@ -75,8 +75,10 @@ describe('SNS Events', () => {
 			return expect(awsAlias.aliasHandleSNSEvents({}, [], {})).to.be.fulfilled
 			.then(() => BbPromise.all([
 				expect(snsStack).to.not.have.a.nested.property('Resources.SNSTopicSlstestprojecttopic'),
+                expect(snsStack).to.not.have.a.nested.property('Resources.SNSTopicSubscriptionSlstestprojecttopic'),
 				expect(snsStack).to.not.have.a.nested.property('Resources.Testfct1LambdaPermissionSlstestprojecttopicSNS'),
 				expect(aliasStack).to.have.a.nested.property('Resources.SNSTopicSlstestprojecttopic'),
+                expect(aliasStack).to.have.a.nested.property('Resources.SNSTopicSubscriptionSlstestprojecttopic'),
 				expect(aliasStack).to.have.a.nested.property('Resources.Testfct1LambdaPermissionSlstestprojecttopicSNS'),
 			]));
 		});

--- a/test/stackops/snsEvents.test.js
+++ b/test/stackops/snsEvents.test.js
@@ -75,10 +75,10 @@ describe('SNS Events', () => {
 			return expect(awsAlias.aliasHandleSNSEvents({}, [], {})).to.be.fulfilled
 			.then(() => BbPromise.all([
 				expect(snsStack).to.not.have.a.nested.property('Resources.SNSTopicSlstestprojecttopic'),
-        expect(snsStack).to.not.have.a.nested.property('Resources.SNSTopicSubscriptionSlstestprojecttopic'),
+				expect(snsStack).to.not.have.a.nested.property('Resources.SNSTopicSubscriptionSlstestprojecttopic'),
 				expect(snsStack).to.not.have.a.nested.property('Resources.Testfct1LambdaPermissionSlstestprojecttopicSNS'),
 				expect(aliasStack).to.have.a.nested.property('Resources.SNSTopicSlstestprojecttopic'),
-        expect(aliasStack).to.have.a.nested.property('Resources.SNSTopicSubscriptionSlstestprojecttopic'),
+				expect(aliasStack).to.have.a.nested.property('Resources.SNSTopicSubscriptionSlstestprojecttopic'),
 				expect(aliasStack).to.have.a.nested.property('Resources.Testfct1LambdaPermissionSlstestprojecttopicSNS'),
 			]));
 		});

--- a/test/stackops/snsEvents.test.js
+++ b/test/stackops/snsEvents.test.js
@@ -75,10 +75,10 @@ describe('SNS Events', () => {
 			return expect(awsAlias.aliasHandleSNSEvents({}, [], {})).to.be.fulfilled
 			.then(() => BbPromise.all([
 				expect(snsStack).to.not.have.a.nested.property('Resources.SNSTopicSlstestprojecttopic'),
-                expect(snsStack).to.not.have.a.nested.property('Resources.SNSTopicSubscriptionSlstestprojecttopic'),
+        expect(snsStack).to.not.have.a.nested.property('Resources.SNSTopicSubscriptionSlstestprojecttopic'),
 				expect(snsStack).to.not.have.a.nested.property('Resources.Testfct1LambdaPermissionSlstestprojecttopicSNS'),
 				expect(aliasStack).to.have.a.nested.property('Resources.SNSTopicSlstestprojecttopic'),
-                expect(aliasStack).to.have.a.nested.property('Resources.SNSTopicSubscriptionSlstestprojecttopic'),
+        expect(aliasStack).to.have.a.nested.property('Resources.SNSTopicSubscriptionSlstestprojecttopic'),
 				expect(aliasStack).to.have.a.nested.property('Resources.Testfct1LambdaPermissionSlstestprojecttopicSNS'),
 			]));
 		});


### PR DESCRIPTION
Closes #94 

This PR adds support for resources of type AWS::SNS::Subscription to be transferred to the alias stack. This resource will be present in the cloudformation template when a lambda subscribes to an existing SNS topic by ARN.

