### PR TITLE
Added support to append ${stageVariables.SERVERLESS_ALIAS} to authorizers of type REQUEST #96

### DIFF
--- a/lib/stackops/apiGateway.js
+++ b/lib/stackops/apiGateway.js
@@ -222,7 +222,8 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 
 		// Audjust authorizer Uri and name (stage variables are not allowed in Uris here)
 		_.forOwn(authorizers, (authorizer, name) => {
-			if (_.get(authorizer, 'Properties.Type') === 'TOKEN') {
+			const authorizerType = _.get(authorizer, 'Properties.Type');
+			if (authorizerType === 'TOKEN' || authorizerType === 'REQUEST') {
 				const uriParts = authorizer.Properties.AuthorizerUri['Fn::Join'][1];
 				const funcIndex = _.findIndex(uriParts, part => _.has(part, 'Fn::GetAtt'));
 

--- a/test/data/auth-stack.json
+++ b/test/data/auth-stack.json
@@ -289,6 +289,37 @@
         "Type": "TOKEN"
       }
     },
+    "TestauthApiGatewayRequestAuthorizer": {
+      "Type": "AWS::ApiGateway::Authorizer",
+      "Properties": {
+        "AuthorizerResultTtlInSeconds": 0,
+        "IdentitySource": "method.request.header.Authorization",
+        "Name": "testauthrequest",
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        },
+        "AuthorizerUri": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:apigateway:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "TestauthLambdaFunction",
+                  "Arn"
+                ]
+              },
+              "/invocations"
+            ]
+          ]
+        },
+        "Type": "REQUEST"
+      }
+    },
     "CognitoTestApiGatewayAuthorizer": {
       "Type": "AWS::ApiGateway::Authorizer",
       "Properties": {


### PR DESCRIPTION
Closes #96 

Added support for authorizers of type **REQUEST** to have ${stageVariables.SERVERLESS_ALIAS} appended to the arn. Currently this is only happening for authorizers that are of type **TOKEN**.