### PR TITLE
Bug Fix - API Gateway template doesn't explicitly state defaults, so old configurations remain

### DIFF
--- a/lib/stackops/apiGateway.js
+++ b/lib/stackops/apiGateway.js
@@ -11,12 +11,12 @@ const BbPromise = require('bluebird');
 const utils = require('../utils');
 
 const stageMethodConfigMappings = {
-	cacheDataEncrypted: { prop: 'CacheDataEncrypted', validate: _.isBoolean, default: false },
+	cacheDataEncrypted: { prop: 'CacheDataEncrypted', validate: _.isBoolean },
 	cacheTtlInSeconds: { prop: 'CacheTtlInSeconds', validate: _.isInteger },
-	cachingEnabled: { prop: 'CachingEnabled', validate: _.isBoolean, default: false },
-	dataTraceEnabled: { prop: 'DataTraceEnabled', validate: _.isBoolean, default: false },
-	loggingLevel: { prop: 'LoggingLevel', validate: value => _.includes([ 'OFF', 'INFO', 'ERROR' ], value), default: 'OFF' },
-	metricsEnabled: { prop: 'MetricsEnabled', validate: _.isBoolean, default: false },
+	cachingEnabled: { prop: 'CachingEnabled', validate: _.isBoolean },
+	dataTraceEnabled: { prop: 'DataTraceEnabled', validate: _.isBoolean },
+	loggingLevel: { prop: 'LoggingLevel', validate: value => _.includes([ 'OFF', 'INFO', 'ERROR' ], value) },
+	metricsEnabled: { prop: 'MetricsEnabled', validate: _.isBoolean },
 	throttlingBurstLimit: { prop: 'ThrottlingBurstLimit', validate: _.isInteger },
 	throttlingRateLimit: { prop: 'ThrottlingRateLimit', validate: _.isNumber }
 };
@@ -79,7 +79,13 @@ const internal = {
 				const eventStageConfig = _.defaults({}, httpEvent.aliasStage, funcStageConfig);
 				if (!_.isEmpty(eventStageConfig)) {
 					const methodType = _.toUpper(httpEvent.method);
-					const methodSetting = {};
+					const methodSetting = {
+						CacheDataEncrypted: false,
+						CachingEnabled: false,
+						DataTraceEnabled: false,
+						LoggingLevel: 'OFF',
+						MetricsEnabled: false
+					};
 					const methods = methodType === 'ANY' ? [
 						'DELETE',
 						'GET',
@@ -96,9 +102,7 @@ const internal = {
 						} else if (!stageMethodConfigMappings[key].validate(value)) {
 							throw new this.serverless.classes.Error(`Invalid value for stage config '${key}: ${value}' at method '${methodType} /${httpEvent.path}'`);
 						}
-						if (!_.has(stageMethodConfigMappings[key], 'default') || stageMethodConfigMappings[key].default !== value) {
-							methodSetting[stageMethodConfigMappings[key].prop] = value;
-						}
+						methodSetting[stageMethodConfigMappings[key].prop] = value;
 					});
 					if (!_.isEmpty(methodSetting)) {
 						methodSetting.ResourcePath = '/' + _.replace('/' + _.trimStart(httpEvent.path, '/'), /\//g, '~1');


### PR DESCRIPTION
The Cloudformation template for API Gateway staging was not including explicitly configured settings if those settings matched one of the defaults.

This was causing issues when trying to go from `dataTraceEnabled: true` back to `dataTraceEnabled: false` (the default setting).  The template was not including the `dataTraceEnabled: false`.  Therefore the API gateway stage configuration was remaining `dataTraceEnabled: true`.

Getting this PR out there while I have a few minutes.  I will add more context later, if needed.